### PR TITLE
[feature] support async rollout

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -456,6 +456,8 @@ actor_rollout_ref:
       # To reduce excessive warnings, you can turn off the sanity check for these models if you are using their default chat template:
       # Qwen/QwQ-32B, Qwen/Qwen3-xxB
       enable_tokenization_sanity_check: True
+
+      format: 'hermes'
   env:
     name: base
     model_type: null

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -241,6 +241,7 @@ class TaskRunner:
             collate_fn=collate_fn,
             train_sampler=train_sampler,
             device_name=config.trainer.device,
+            env_object=env_object
         )
         # Initialize the workers of the trainer.
         trainer.init_workers()

--- a/verl/workers/rollout/async_server.py
+++ b/verl/workers/rollout/async_server.py
@@ -100,7 +100,7 @@ class AsyncServerBase(ABC):
 class AsyncLLMServerManager:
     """AsyncLLMServerManager manage a group of vllm instances, i.e AsyncvLLMServer."""
 
-    def __init__(self, config: DictConfig, worker_group: RayWorkerGroup):
+    def __init__(self, config: DictConfig, worker_group: RayWorkerGroup, env_object=None):
         """Initialize AsyncLLMServerManager.
 
         Args:
@@ -110,6 +110,7 @@ class AsyncLLMServerManager:
         self.full_config = config
         self.config = config.actor_rollout_ref
         self.worker_group = worker_group
+        self.env_object = env_object
 
         self.rollout_tp_size = self.config.rollout.tensor_model_parallel_size
         self.rollout_dp_size = self.worker_group.world_size // self.rollout_tp_size
@@ -168,6 +169,7 @@ class AsyncLLMServerManager:
         self.chat_scheduler = ChatCompletionScheduler(
             config=self.full_config,
             server_addresses=self.server_addresses,
+            env_object=self.env_object
         )
 
         self.chat_scheduler_ready.set()


### PR DESCRIPTION
This PR supports issue #35 . We incorporate RL-Factory's decoupled tool manager into VeRL's asynchronous LLM rollout framework. 

## implementation

Our main motifications to VeRL's asynchronou rollout implemtation are:
* pass `env_object` into class `ToolCompletionCallback` and use our tool manager (i.e. `env_object.tool_manager`) to parse response, call tool and get prompt. [in class `ToolCompletionCallback` - `async def __call__`]
* preprocess messages using our tool manager and extract system prompt with tool description, to be compatible with our implementation in sync setting. And also update `batch.non_tensor_batch["raw_prompt"]` to make sure the postprocess can be done correctly. [in class `ChatCompletionScheduler` - `async def generate_sequences`]

Other minor updates:
* add `actor_rollout_ref.rollout.multi_turn.format: 'hermes` [in ppo_trainer.yaml]
* [fix bug] fix the "generate sequences" calling bug in `RayPPOTrainer`'s `fit` and `_validate`
* add loss_mask in `ToolCompletionCallback.postprocess`
* add `enbale_thinking` in `extra_body` of `ToolCompletionCallback`


## configs for async rollout
To use asynchronous rollout, you need to modify some configs:
* `export VLLM_USE_V1=1`
* `actor_rollout_ref.rollout.mode="async"`
* `data.return_raw_chat=True`
* use `actor_rollout_ref.rollout.multi_turn.max_turns` (instead of `actor_rollout_ref.rollout.max_turns`)
* set `actor_rollout_ref.rollout.max_model_len` large enough that context length won't exceed it. (If excced, it will raise an error in `ChatCompletion(**data)`, and this conversation will be terminated. But it will not stop the training procedure.)