### PR TITLE
Fix bug on search mcp return type

### DIFF
--- a/envs/tools/search.py
+++ b/envs/tools/search.py
@@ -4,7 +4,7 @@ from mcp.server.fastmcp import FastMCP  # 假设您已有这个基础库
 mcp = FastMCP("LocalServer")
 
 @mcp.tool()
-def query_rag(query: str, topk: int = 3) -> str:
+def query_rag(query: str, topk: int = 3):
     """MCP RAG Query Tool (Synchronous Version)
     
     Args:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -100,10 +100,8 @@ class TaskRunner:
                     max_concurrency=config.actor_rollout_ref.env.get('max_concurrency', 10)
                 ).remote(config.actor_rollout_ref.env)
         
-        config_path = os.path.join(local_path, "config.json")
-        with open(config_path, "r", encoding="utf-8") as f:
-            model_config = json.load(f)
-        config.actor_rollout_ref.env.model_type = model_config.get("model_type", "unknown")
+        model_config = AutoConfig.from_pretrained(local_path)
+        config.actor_rollout_ref.env.model_type = getattr(model_config, "model_type", "unknown")
 
         env_object = TOOL_ENV_REGISTRY[config.actor_rollout_ref.env.name](
             config=config.actor_rollout_ref.env,


### PR DESCRIPTION
This PR fixes bugs on `query_rag` function return type of search mcp `env/tools/search.py`. 