### PR TITLE
merge branch verl_0_5 and vllm_tool

### DIFF
--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -1,12 +1,15 @@
 from .base import Env as BaseEnv
+from .mmbase import MMEnv
 from .search import SearchEnv
 from .vision import VisionEnv
 from .reward_rollout_example import RewardRolloutEnv
 
-__all__ = ['BaseEnv', 'SearchEnv', 'RewardRolloutEnv', 'VisionEnv']
+
+__all__ = ['BaseEnv', 'SearchEnv', 'RewardRolloutEnv', 'VisionEnv', 'MMEnv']
 
 TOOL_ENV_REGISTRY = {
     'base': BaseEnv,
+    'mmbase': MMEnv,
     'search': SearchEnv,
     'reward_rollout': RewardRolloutEnv,
     'vision': VisionEnv

--- a/envs/configs/chat_template.jinja
+++ b/envs/configs/chat_template.jinja
@@ -1,0 +1,94 @@
+{% set image_count = namespace(value=0) %}
+{% set video_count = namespace(value=0) %}
+{{- '<|im_start|>system\n' }}
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {{ messages[0]['content'] }}
+    {%- else -%}
+        {%- for content in messages[0]['content'] -%}
+            {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
+                {%- set image_count.value = image_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{ 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif -%}
+                {{ '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif content['type'] == 'video' or 'video' in content -%}
+                {%- set video_count.value = video_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{ 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif -%}
+                {{ '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in content -%}
+                {{ content['text'] }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- else -%}
+    {{ 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+{%- endif -%}
+{%- if tools -%}
+    {{ '\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n' }}
+    {{- tools | map('tojson') | join('\n') -}}
+    {{ '\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call>' }}
+{%- endif -%}
+{{ '<|im_end|>\n' }}
+{%- for message in messages -%}
+    {# Skip the first system message as it was already rendered. #}
+    {%- if loop.first and message.role == 'system' %}{% continue %}{% endif -%}
+
+    {# Render tool messages. The logic is slightly different with other messages. #}
+    {%- if message['role'] == 'tool' -%}
+        {%- if loop.first or messages[loop.index0 - 1]['role'] != 'tool' -%}
+            {{ '<|im_start|>user' }}
+        {%- endif -%}
+        {{ '\n<tool_response>\n' }}
+    {%- else -%}
+        {{ '<|im_start|>' ~ message['role'] ~ '\n' }}
+    {%- endif -%}
+
+    {%- if message['content'] is string -%}
+        {{ message['content'] }}
+    {%- else -%}
+        {%- for content in message['content'] -%}
+            {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
+                {%- set image_count.value = image_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{ 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif -%}
+                {{ '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif content['type'] == 'video' or 'video' in content -%}
+                {%- set video_count.value = video_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{ 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif -%}
+                {{ '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in content -%}
+                {{ content['text'] }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {# Render tool_calls in AI messages. #}
+    {%- if message['role'] == 'assistant' and 'tool_calls' in message -%}
+        {# It will be cleaner if I can use some map function and join them with '\n' #}
+        {%- for tool_call in message['tool_calls'] -%}
+            {%- if tool_call['function'] is defined -%}
+                {%- set tool_call = tool_call['function'] -%}
+            {%- endif -%}
+            {{ '<tool_call>\n' }}{{ tool_call | tojson }}{{ '\n</tool_call>' }}
+            {%- if not loop.last -%}
+                {{ '\n' }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- if message['role'] == 'tool' -%}
+        {{ '\n</tool_response>' }}
+        {%- if loop.last or messages[loop.index0 + 1]['role'] != 'tool' -%}
+            {{ '<|im_end|>\n' }}
+        {%- endif -%}
+    {%- else -%}
+        {{ '<|im_end|>\n' }}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{ '<|im_start|>assistant\n' }}
+{%- endif -%}

--- a/envs/configs/mcp_vision_tools.pydata
+++ b/envs/configs/mcp_vision_tools.pydata
@@ -1,6 +1,6 @@
 [
     {'mcpServers': {
-        'rotate': {
+        'vision': {
             'command': 'python3',
             'args': ['envs/tools/rotate.py']
         }

--- a/envs/mmbase.py
+++ b/envs/mmbase.py
@@ -1,0 +1,357 @@
+import re
+import torch
+import string
+import random
+from abc import ABC
+from verl import DataProto
+from envs.tool_manager import TOOL_MANAGER_REGISTRY
+from verl.utils.model import compute_position_id_with_mask
+from verl.utils.torch_functional import tokenize_and_postprocess_data
+from typing import List, Tuple
+from PIL import Image
+import sys
+from copy import deepcopy
+
+
+class MMEnv(ABC):
+    def __init__(self, config, centralized_actor=None):
+        tool_manager_name = config.get('tool_manager', 'qwen3')
+        # 检查是否指定工具管理器，如果没有采用自适应模式Add commentMore actions
+        if not tool_manager_name:
+            tool_manager_name = "adaptive"
+        if tool_manager_name.startswith('centralized_'):
+            if centralized_actor is None:
+                raise ValueError(f"使用集中式工具管理器 '{tool_manager_name}' 需要提供 centralized_actor 参数")
+            self.tool_manager = TOOL_MANAGER_REGISTRY[tool_manager_name](
+                verl_config=config, 
+                centralized_actor_handle=centralized_actor
+            )
+        else:
+            # 分布式模式，保持原有逻辑
+            if tool_manager_name == 'adaptive':
+                model_type = config.get('model_type')
+                if 'qwen3' in model_type:
+                    tool_manager_name = 'qwen3'
+                elif 'qwen2' in model_type:
+                    tool_manager_name = 'qwen2_5'
+                elif 'qwen2_5_vl' in model_type:
+                    tool_manager_name = 'qwen2_5_vl'
+                elif 'llama' in model_type:
+                    tool_manager_name = 'llama3'  
+                else:
+                    tool_manager_name = model_type
+                    raise ValueError(f"'{tool_manager_name}' 需要进行适配，请添加一个对应的tool_manager")                   
+
+            self.tool_manager = TOOL_MANAGER_REGISTRY[tool_manager_name](verl_config=config)
+        # breakpoint()
+        # self.processor = self.tool_manager.processor
+        # breakpoint()
+        self.max_prompt_length = config.get('max_prompt_length', 2048)
+        self.use_verify_tool = False
+        self.use_process_reward = config.get('use_process_reward', False)
+        self.chat_template = config.get('chat_template', None)
+        
+    def verify_tool(self, data_source, solution_str, ground_truth, extra_info):
+        # If you need a tool to evaluate the generated response, you need to modify the following code
+        # the data would be stored in data[i].non_tensor_batch['reward_model']['ground_truth']['verified_results']
+        # print('verify tool start')
+        raise NotImplementedError
+
+    def _process_data(self, data_item, tokenizer):
+        # process the data_item to the token and decode them
+        prompt_ids = data_item.batch['prompts']
+
+        prompt_length = prompt_ids.shape[-1]
+
+        valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
+        valid_prompt_ids = prompt_ids[-valid_prompt_length:]
+
+        response_ids = data_item.batch['responses']
+        valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+        valid_response_ids = response_ids[:valid_response_length]
+
+        # decode
+        prompt_str = tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
+        # prompt_str = tokenizer.decode(valid_prompt_ids)
+        # response_str = tokenizer.decode(valid_response_ids)
+        # response_str = response_str.replace("<|image_pad|>", "") 
+        response_str = tokenizer.decode(valid_response_ids, skip_special_tokens=True)
+        ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
+        data_source = data_item.non_tensor_batch['data_source']
+        extra_info = data_item.non_tensor_batch.get('extra_info', None)
+        
+        return {
+            'prompt_str': prompt_str,
+            'response_str': response_str,
+            'ground_truth': ground_truth,
+            'data_source': data_source,
+            'extra_info': extra_info
+        }
+    def _replace_all_image_pads(self, original_str, count, processor):
+        """
+        将一个字符串中所有的 '<image_pad>' 替换为指定数量的 '<image_pad>'。
+
+        参数:
+        original_str (str): 原始输入字符串。
+        count (int): 希望替换成的 '<image pad>' 的数量。
+
+        返回:
+        str: 替换后的新字符串。
+        """
+        # 1. 根据数量生成替换用的字符串
+        # 例如，当 count=3 时，replacement 为 "<image pad> <image pad> <image pad>"
+        replacement = ' '.join(['<|image_pad|>'] * count)
+        # 2. 使用 replace() 方法进行全局替换
+        new_str = original_str.replace('<|image_pad|>', replacement)
+        return new_str
+    
+    def get_step_reward(self, responses, format_score=0.1):
+        step_reward = [1] * len(responses)
+        return step_reward 
+    
+    def _mm_process(self, mm_output, image_result, temp_next_obs, processor):
+        if not mm_output:
+            return None, None, temp_next_obs
+        mm_data = processor.image_processor(image_result, return_tensors='pt')
+        temp_multi_modal_data = {"pixel_values": mm_data["pixel_values"], "image_grid_thw": mm_data["image_grid_thw"]}
+        temp_image_data = image_result
+        temp_next_obs = self._replace_all_image_pads(temp_next_obs, mm_data["image_grid_thw"][0].prod() // (processor.image_processor.merge_size**2),processor)
+        return temp_multi_modal_data, temp_image_data, temp_next_obs
+    
+    def step(self, responses, processor, image_data: List[List[Image.Image]]):
+        tokenizer = processor.tokenizer
+        print("start to the env step", file=sys.stderr, flush=True)
+        cur_actions, tool_results = self.tool_manager.execute_actions(responses=responses, image_data=image_data)
+        next_obs, dones, valid_action, is_tool, new_image = [], [], [], [], []
+        raw_prompt = []
+        multi_modal_data = []
+        valid_tool = []
+        
+        for action, tool_result in zip(cur_actions, tool_results):
+            # print(f" action: {action} tool_result: {tool_result}\n\n")
+            tool_result = tool_result[0]
+            image_result = tool_result[1]
+            mm_output = True if image_result is not None else False
+            temp_valid_tool = 0
+            temp_multi_modal_data = None
+            temp_raw_prompt = None
+            if action == 'answer':
+                temp_next_obs, temp_done, temp_valid_action, temp_is_tool, temp_image_data, temp_valid_tool, temp_raw_prompt = '', True, 0, 1, None, 0, None
+            elif action == 'error':
+                temp_next_obs = self.tool_manager.get_prompt(
+                    input_data=tool_result, 
+                    tokenizer=tokenizer,
+                    mode='tool_call', 
+                    add_generation_prompt=True
+                )
+                temp_done, temp_valid_action, temp_is_tool, temp_image_data, temp_raw_prompt = False, 0, 0, None, temp_next_obs
+            elif action == 'actions':
+                # print(f" action: {action} tool_result: {tool_result}\n\n")
+
+                temp_next_obs = self.tool_manager.get_prompt(
+                    input_data=tool_result[0],
+                    tokenizer=tokenizer,
+                    mode='tool_call',
+                    add_generation_prompt=True
+                )
+                temp_raw_prompt = deepcopy(temp_next_obs)
+                if mm_output and "<|image_pad|>" not in temp_next_obs:
+                    print(f"mm_output and <|image_pad|> not in temp_next_obs")
+                    breakpoint()
+                temp_multi_modal_data, temp_image_data, temp_next_obs = self._mm_process(mm_output, image_result, temp_next_obs, processor)
+                temp_done, temp_valid_action, temp_is_tool, temp_valid_tool = False, 0, 1, 1 if mm_output else 0
+            else:
+                raise ValueError('Unexpected action: {}'.format(action))
+            
+            next_obs.append(temp_next_obs)
+            dones.append(temp_done)
+            valid_action.append(temp_valid_action)
+            is_tool.append(temp_is_tool)
+            new_image.append(temp_image_data)
+            multi_modal_data.append(temp_multi_modal_data)
+            valid_tool.append(temp_valid_tool)
+            raw_prompt.append(temp_raw_prompt)
+
+        print(f"image valid tool execute is {sum(valid_tool)} and overall batch size is  {len(dones)}",file=sys.stderr, flush=True)
+        assert sum(valid_tool) == sum(1 for item in new_image if isinstance(item, Image.Image))
+        return next_obs, dones, valid_action, is_tool, new_image, raw_prompt, multi_modal_data, valid_tool
+    
+
+    def compute_score(self, reward_rollout_wg, reward_tokenizer, tokenizer, data: DataProto, if_val=False, use_process_reward=False):
+        if reward_rollout_wg is not None:
+            scores = self._compute_score_with_reward_rollout_wg(reward_rollout_wg, reward_tokenizer, data)
+        else:
+            score = self._compute_score_with_rules(data, tokenizer, if_val=if_val)
+            if use_process_reward and not if_val:
+                scores = []
+                for i in range(len(data)):
+                    data_item = data[i]
+                    tool_use_score = data_item.batch['tool_use_scores']
+                    validate_score = tool_use_score[ ~ torch.isnan(tool_use_score)].tolist()
+                    scores.append(validate_score + score[i])
+            else:
+                scores = score
+        
+        return scores
+    
+    def _compute_score_with_rules(self, data, tokenizer, if_val=False):
+        for i in range(len(data)):
+            data_item = data[i]  # DataProtoItem
+
+            # process the data_item to the token and decode them
+            processed_data = self._process_data(data_item=data_item, tokenizer=tokenizer)
+            ground_truth, response_str = processed_data['ground_truth'], processed_data['response_str']
+
+            # reserved for compatibility
+            prompt_str, data_source, extra_info = processed_data['prompt_str'], processed_data['data_source'], processed_data['extra_info']
+
+        scores = [[0.0]] * len(data)
+        
+        return scores
+
+    def get_prompt_for_reward(self, reward_tokenizer, data: DataProto):
+        reward_prompt_strs = []
+        
+        for i in range(len(data)):
+            data_item = data[i]
+            step_mask = data.batch['step_mask'][i]
+            
+            # 获取有效的prompt和response
+            prompt_ids = data_item.batch['prompts']
+            prompt_length = prompt_ids.shape[-1]
+            
+            response_ids = data_item.batch['responses']
+            valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+            valid_response_ids = response_ids[:valid_response_length]
+            
+            # 获取非tensor数据
+            non_tensor_data = {
+                'data_source': data_item.non_tensor_batch['data_source'],
+                'ground_truth': data_item.non_tensor_batch['reward_model']['ground_truth'],
+                'extra_info': data_item.non_tensor_batch.get('extra_info', None)
+            }
+            
+            # 找到所有step的位置
+            mask_indices = torch.where(step_mask == 1)[0]
+            assert len(mask_indices) > 0, "no step mask"
+            
+            # 处理所有responses
+            reward_prompt_str_list = []
+            start_idx = 0
+            
+            for end_idx in mask_indices:
+                # 截取当前response
+                current_response = valid_response_ids[start_idx:end_idx]
+                current_response_str = reward_tokenizer.decode(current_response, skip_special_tokens=True)
+                
+                # 生成prompt
+                reward_prompt_str = self._get_single_prompt_str(
+                    data_source=non_tensor_data['data_source'],
+                    solution_str=current_response_str,
+                    ground_truth=non_tensor_data['ground_truth'],
+                    extra_info=non_tensor_data['extra_info'],
+                    reward_tokenizer=reward_tokenizer
+                )
+                reward_prompt_str_list.append(reward_prompt_str)
+                
+                start_idx = end_idx
+
+            assert start_idx == len(valid_response_ids) - 1, "start_idx is not the last index"
+
+            reward_prompt_strs.append(reward_prompt_str_list)
+        
+        return reward_prompt_strs
+    
+    def _get_single_prompt_str(self, data_source, solution_str, ground_truth, extra_info, reward_tokenizer):
+        # If you need use the reasoning model to generate the reward, you need to modify the following code
+        # result = reward_tokenizer.apply_chat_template([
+        #     {'role': 'system', 'content': 'You are a assistant. '},
+        #     {'role': 'user', 'content': '你是Qwen吗？你只需要回答是或者不是即可。'}
+        # ], add_generation_prompt=True, tokenize=False)
+        # return result
+        raise NotImplementedError
+
+    def _compute_score_with_reward_rollout_wg(self, reward_rollout_wg, reward_tokenizer, data: DataProto):
+        # 基于actor rollout的回答和真实答案构造judge model的prompts
+        reward_prompt_strs = self.get_prompt_for_reward(reward_tokenizer, data)
+        
+        # 展平reward_prompt_strs为一个batch
+        flat_prompts = []
+        original_shapes = []  # 记录每个样本的prompt数量
+        for prompts in reward_prompt_strs:
+            original_shapes.append(len(prompts))
+            flat_prompts.extend(prompts)
+        
+        # 将flat_prompts转换为DataProto格式
+        input_ids = []
+        attention_mask = []
+        for prompt in flat_prompts:
+            # 使用 tokenize_and_postprocess_data 处理每个 prompt
+            ids, mask = tokenize_and_postprocess_data(
+                prompt=prompt,
+                tokenizer=reward_tokenizer,
+                max_length=self.max_prompt_length,
+                pad_token_id=reward_tokenizer.pad_token_id,
+                left_pad=True,
+                truncation='error'
+            )
+            input_ids.append(ids)
+            attention_mask.append(mask)
+
+        # 创建DataProto
+        tensors = {
+            "input_ids": torch.cat(input_ids, dim=0),
+            "attention_mask": torch.cat(attention_mask, dim=0)
+        }
+        
+        # 计算position_ids
+        tensors["position_ids"] = compute_position_id_with_mask(tensors["attention_mask"])
+
+        data_proto = DataProto.from_dict(tensors=tensors)
+        
+        # 生成responses
+        responses_data = reward_rollout_wg.generate_sequences(data_proto)
+        
+        # 计算每个response的分数
+        flat_scores = []
+        for i, temp_response_data in enumerate(responses_data):
+            # 找到对应的data_item
+            data_idx = 0
+            prompt_count = 0
+            while data_idx < len(original_shapes) and prompt_count + original_shapes[data_idx] <= i:
+                prompt_count += original_shapes[data_idx]
+                data_idx += 1
+            
+            data_item = data[data_idx]
+
+            temp_prompt_ids = temp_response_data.batch['prompts']
+            temp_prompt_length = temp_prompt_ids.shape[-1]
+            temp_response_ids = temp_response_data.batch['responses']
+            temp_valid_response_length = temp_response_data.batch['attention_mask'][temp_prompt_length:].sum()
+            temp_valid_response_ids = temp_response_ids[:temp_valid_response_length]
+            response_str = reward_tokenizer.decode(temp_valid_response_ids, skip_special_tokens=True)
+
+            score = self._compute_single_score_with_reward_rollout_wg(
+                data_item.non_tensor_batch['data_source'], 
+                response_str, 
+                data_item.non_tensor_batch['reward_model']['ground_truth'], 
+                data_item.non_tensor_batch.get('extra_info', None)
+            )
+            flat_scores.append(score)
+        
+        assert data_idx == len(data) - 1, "data_idx is {}".format(data_idx)
+        
+        # 将scores重新组织为原来的形状
+        scores = []
+        start_idx = 0
+        for shape in original_shapes:
+            end_idx = start_idx + shape
+            scores.append(flat_scores[start_idx:end_idx])
+            start_idx = end_idx
+        
+        return scores
+    
+    def _compute_single_score_with_reward_rollout_wg(self, data_source, solution_str, ground_truth, extra_info):
+        # print("solution_str: ", solution_str)
+        # return 1.0
+        raise NotImplementedError

--- a/envs/tool_manager/mm_base_manager.py
+++ b/envs/tool_manager/mm_base_manager.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+import traceback
+from typing import List, Union
+from abc import ABC, abstractmethod
+from PIL import Image
+from envs.storage.manager.storage_manager import create_config_storage_manager
+from envs.utils.util import ToolServiceError, DocParserError
+import json
+import io
+import base64
+import binascii
+
+class ToolManager(ABC):
+    def __init__(self, verl_config) -> None:
+        self.verl_config = verl_config
+        self.tool_map = {}
+        self._build_tools()
+        self.build_storage_manager(self.verl_config)
+
+    def build_storage_manager(self, verl_config):
+        self.storage_manager = create_config_storage_manager(verl_config)
+        # jjw
+        self.storage_manager = None
+
+    def get_tool(self, name_or_short_name: str):
+        """通过名称或简写获取工具
+        
+        Args:
+            name_or_short_name: 工具名称或简写
+            
+        Returns:
+            找到的工具，如果没找到则返回None
+        """
+        name_or_short_name = str(name_or_short_name)
+        return self.tool_map.get(name_or_short_name, None)
+
+    @property
+    @abstractmethod
+    def all_tools(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _build_tools(self):
+        raise NotImplementedError
+
+    def _call_tool(self, tool_name: str, tool_args: Union[str, dict] = '{}', **kwargs):
+        """The interface of calling tools for the agent.
+
+          Args:
+              tool_name: The name of one tool.
+              tool_args: Model generated or user given tool parameters.
+
+          Returns:
+              The output of tools.
+          """
+        if tool_name not in self.tool_map:
+            return f'Tool {tool_name} does not exists.'
+        tool = self.get_tool(tool_name)
+        tool_result = None
+        try:
+            if self.storage_manager is not None:
+                tool_result = asyncio.get_event_loop().run_until_complete(self.storage_manager.get(tool_name, tool_args))
+            if tool_result is not None:
+                return tool_result
+            else:
+                tool_result = tool.call(tool_args, **kwargs)
+
+            if self.storage_manager is not None:
+                asyncio.get_event_loop().run_until_complete(self.storage_manager.set(tool_name, tool_args, tool_result, ttl=30))
+
+        except (ToolServiceError, DocParserError) as ex:
+            raise ex
+        except Exception as ex:
+            exception_type = type(ex).__name__
+            exception_message = str(ex)
+            traceback_info = ''.join(traceback.format_tb(ex.__traceback__))
+            error_message = f'An error occurred when calling tool `{tool_name}`:\n' \
+                            f'{exception_type}: {exception_message}\n' \
+                            f'Traceback:\n{traceback_info}'
+            return error_message
+        # print("tool_result type: ", type(tool_result))
+
+        if self.is_base64(tool_result):
+            print("tool_result is base64")
+            return self.base64_to_pil(tool_result)
+        elif isinstance(tool_result, str):
+            return tool_result
+        else:
+            return json.dumps(tool_result, ensure_ascii=False, indent=4)
+
+    @abstractmethod
+    def execute_actions(self, responses: List[str]):
+        raise NotImplementedError
+    
+    def pil_to_base64(self, image):
+        img_buffer = io.BytesIO()
+        image.save(img_buffer, format='PNG')
+        img_base64 = base64.b64encode(img_buffer.getvalue()).decode('utf-8')
+        return img_base64
+    
+    def base64_to_pil(self, base64_str):
+        img_data = base64.b64decode(base64_str)
+        image = Image.open(io.BytesIO(img_data))
+        return image
+   
+
+    def is_base64(self, s):
+        head = base64.b64decode(s[:100], validate=True)
+        # 检查常见图片文件头
+        return head.startswith((b'\xff\xd8\xff', b'\x89PNG\r\n\x1a\n', b'GIF87a', b'GIF89a', b'BM'))

--- a/envs/tools/rotate.py
+++ b/envs/tools/rotate.py
@@ -19,7 +19,7 @@ def rotate(degree: int, img_base64: str) -> str:
     Returns:
         str: The Base64 encoded string of the rotated image.
     """
-    print(f"================= Calling image_rotate tool ==================\n\n\n\n\n\n\n\n\n")
+    print(f"================= Calling image_rotate tool ==================")
     print(f"Received parameters: degree={degree}, img_base64 length={len(img_base64) if img_base64 else 0}")
 
     if img_base64 is None:

--- a/envs/tools/rotate.py
+++ b/envs/tools/rotate.py
@@ -1,55 +1,53 @@
-
 from PIL import Image
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.fastmcp.tools.base import Tool
 from io import BytesIO
 import base64
 import binascii
+import inspect # For inspecting function signature in decorator
+from typing import Any, Callable, List # For type hints
 
-# Initialize MCP server
-mcp = FastMCP("ImageRotateServer")
-
+mcp = FastMCP("LocalServer")
 
 @mcp.tool()
-def rotate(img_base64: str = None, degree: int = None) -> str:
-    """Rotate a Pillow image by specified degrees
-    
+def rotate(degree: int, img_base64: str) -> str:
+    """Rotate the image by a specified angle.
+
     Args:
-        img_base64: Input image as base64 encoded string
-        degree: Rotation angle in degrees (positive for clockwise, negative for counterclockwise)
-        
+        degree (int): The angle of rotation (positive for clockwise, negative for counter-clockwise).
+
     Returns:
-        str: Rotated image as base64 encoded string
+        str: The Base64 encoded string of the rotated image.
     """
-    print("================= call image_rotate tool ==================")
-    
-    # Validate required parameters
+    print(f"================= Calling image_rotate tool ==================\n\n\n\n\n\n\n\n\n")
+    print(f"Received parameters: degree={degree}, img_base64 length={len(img_base64) if img_base64 else 0}")
+
     if img_base64 is None:
-        return "⚠️ Error: img_base64 parameter is required"
-    
+        return "Error: Missing image data"
+
     if degree is None:
-        return "⚠️ Error: degree parameter is required"
-    
+        return "Error: Missing degree parameter"
+
     try:
-        # Convert base64 string to PIL Image
         img_data = base64.b64decode(img_base64)
         img = Image.open(BytesIO(img_data))
-        
-        # Rotate the image
+
         rotated_img = img.rotate(degree, expand=True)
-        
-        # Convert PIL Image back to base64 string
+
         buffer = BytesIO()
         rotated_img.save(buffer, format='PNG')
         img_base64_output = base64.b64encode(buffer.getvalue()).decode('utf-8')
-        
+        print(f" {'*'*50}\n\n\n\n\n use image success {'*'*50}\n\n\n")
         return img_base64_output
-        
-    except (base64.binascii.Error, binascii.Error):
-        return "⚠️ Error: Invalid base64 image data"
+
+    except binascii.Error:
+        return "Error: Invalid base64 image data"
     except Exception as e:
-        return f"⚠️ Image rotation failed: {str(e)}"
+        return f"Image rotation failed: {str(e)}"
+    
+
 
 
 if __name__ == "__main__":
-    print("\nStarting MCP Image Rotation Service...")
+    print("\n启动 MCP 图像旋转服务...")
     mcp.run(transport='stdio')

--- a/envs/utils/mcp_manager.py
+++ b/envs/utils/mcp_manager.py
@@ -273,13 +273,13 @@ class MCPManager:
             client_id = register_client_id
             _manager = manager_instance  # 在类中保存manager实例的引用
 
-            async def call(self, params: Union[str, dict], **kwargs) -> str:
+            def call(self, params: Union[str, dict], **kwargs) -> str:
                 tool_args = json.loads(params)
                 # 使用保存的manager实例而不是获取新的单例
                 client = self._manager.clients[self.client_id]
-                # future = asyncio.run_coroutine_threadsafe(client.execute_function(tool_name, tool_args), self._manager.loop)
+                future = asyncio.run_coroutine_threadsafe(client.execute_function(tool_name, tool_args), self._manager.loop)
                 try:
-                    result = await client.execute_function(tool_name, tool_args)
+                    result = future.result()
                     return result
                 except Exception as e:
                     logger.info(f'Failed in executing MCP tool: {e}')

--- a/envs/utils/mm_tool_utils.py
+++ b/envs/utils/mm_tool_utils.py
@@ -1,0 +1,321 @@
+import torch
+import os
+import logging
+import itertools
+import numpy as np
+from verl import DataProto
+import torch.distributed as dist
+from tensordict import TensorDict
+from typing import List
+from PIL import Image
+import sys
+from .tool_utils import ToolUtils
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+class MMToolUtils(ToolUtils):
+    def __init__(self, tokenizer, processor, meta_info, config, env_object):
+        super().__init__(tokenizer, meta_info, config, env_object)
+        self.processor = processor
+
+        
+        pad_token_id = meta_info.get('pad_token_id')
+        if pad_token_id is not None:
+            self.pad_token_id = pad_token_id
+        else:
+            eos_token_id = meta_info.get('eos_token_id')
+            if isinstance(eos_token_id, (list, tuple)):
+                self.pad_token_id = eos_token_id[-1]
+            else:
+                self.pad_token_id = eos_token_id
+                
+        eos_token_id = meta_info.get('eos_token_id')
+        if isinstance(eos_token_id, (list, tuple)):
+            self.eos_token_id = eos_token_id[0]
+        else:
+            self.eos_token_id = eos_token_id
+        
+        self.meta_info = meta_info
+        self.loop_cnt = 0
+
+        self.env_object = env_object
+        
+        # Qwen2.5VL mrope specific parameters
+        self.vision_start_token_id = getattr(tokenizer, 'vision_start_token_id', 151652)
+        self.image_token_id = getattr(tokenizer, 'image_token_id', 151655) 
+        self.video_token_id = getattr(tokenizer, 'video_token_id', 151656)
+        self.spatial_merge_size = 2
+        self.tokens_per_second = 2
+
+    def postprocess_output(self, output: DataProto, step: int):
+        print(f"[ToolUtils] start the {step}th postprocess",file=sys.stderr,flush=True)
+        '''output: cpu'''
+        if self.loop_cnt == 0:
+            self.batch_size = output.batch.batch_size[0]
+            self.loop_responses_token = [[] for _ in range(self.batch_size)]
+            
+            self.loop_raw_responses_token = [[] for _ in range(self.batch_size)]
+            self.init_prompt_token = output.batch.get('prompts')
+            self.raw_prompt_id = output.non_tensor_batch.get('raw_prompt_ids')
+
+            self.multi_modal_inputs = [[] for _ in range(self.batch_size)]
+            self.image_list = [i["image"] for i in output.non_tensor_batch["multi_modal_data"]]
+            self.tool_use = [[] for _ in range(self.batch_size)]
+            prompt_length = self.init_prompt_token.shape[-1]
+            self.init_attention_mask = output.batch.get('attention_mask')[:,:prompt_length]
+
+            batch_idxs = list(range(self.batch_size))
+            
+            for idx in range(self.batch_size):
+
+                self.multi_modal_inputs[idx].append(output.non_tensor_batch["multi_modal_inputs"][idx])
+
+                prompt_token = self.init_prompt_token[idx]
+                assert isinstance(prompt_token, torch.Tensor)
+                prompt_token_list = prompt_token[prompt_token != self.pad_token_id].tolist()
+
+                self.loop_responses_token[idx].append(prompt_token_list)
+                self.loop_raw_responses_token[idx].append(self.raw_prompt_id[idx])
+
+        else:
+            batch_idxs = output.meta_info['index']
+        responses = output.batch.get('responses')
+
+        process_response = []
+        for idx, batch_idx in enumerate(batch_idxs):
+            response_token = responses[idx]
+            response_token_list = response_token[response_token != self.pad_token_id].tolist()
+            if self.env_object.use_process_reward:
+            # assure last token is stop token （add or change）
+                if response_token_list[-1] != self.stop_id:
+                    if len(response_token_list) != self.config_response_length:
+                        response_token_list.append(self.stop_id)
+                    else:
+                        response_token_list[-1] = self.stop_id
+            self.loop_responses_token[batch_idx].append(response_token_list)
+            self.loop_raw_responses_token[batch_idx].append(response_token_list)
+            process_response.append(response_token_list)
+
+        responses_str = self.tokenizer.batch_decode(
+            process_response,
+            skip_special_tokens=False,
+        )
+        
+        # breakpoint()
+        infos_str, dones, _, _, new_image_data, raw_prompt, multi_modal_data, valid_tool = self.env_object.step(
+            responses=responses_str, processor=self.processor, image_data=self.image_list
+        )
+        # breakpoint()
+        for idx, batch_idx in enumerate(batch_idxs):
+            if multi_modal_data[idx] is not None:
+                self.multi_modal_inputs[batch_idx].append(multi_modal_data[idx])
+
+        #if not use_process_reward will be 0
+        if self.env_object.use_process_reward:
+            step_scores = self.env_object.get_step_reward(responses=responses_str)
+        else:
+            step_scores = [0] * len(responses_str)
+
+
+        def tokenize_infos(infos_str):
+            if infos_str == "":
+                return []
+            if infos_str is None:
+                return []
+            try:
+                info_tokens = self.tokenizer(text=infos_str).input_ids
+            except:
+                raise ValueError(f"tokenize_infos error, the infos_str is {infos_str}")
+            return info_tokens
+
+        next_prompt_token = []
+        next_prompt_length = []
+        next_sample_idx = []
+        next_image_data = []
+        next_raw_prompt_token = []
+        next_raw_prompt_length = []
+
+        for idx, batch_idx in enumerate(batch_idxs):
+            if not dones[idx]:
+                info_token_list = tokenize_infos(infos_str[idx])
+                raw_prompt_list = tokenize_infos(raw_prompt[idx])
+                # breakpoint()
+                self.loop_responses_token[batch_idx].append(info_token_list)
+                self.loop_raw_responses_token[batch_idx].append(raw_prompt_list)
+                next_sample_idx.append(batch_idx)
+                promt_token = list(itertools.chain.from_iterable(self.loop_responses_token[batch_idx]))
+                raw_prompt_token = list(itertools.chain.from_iterable(self.loop_raw_responses_token[batch_idx]))
+                next_prompt_token.append(promt_token)
+                next_raw_prompt_token.append(raw_prompt_token)
+                next_prompt_length.append(len(promt_token))
+                next_raw_prompt_length.append(len(raw_prompt_token))
+                self.tool_use[batch_idx].append(step_scores[idx])
+                if valid_tool[idx]:
+                    self.image_list[batch_idx].append(new_image_data[idx])
+                next_image_data.append(self.image_list[batch_idx])
+        
+        if len(next_prompt_token) == 0:
+            return 
+        
+        # left pad
+        max_len = (max(next_prompt_length) + self.config_prompt_length)
+        
+        next_prompt_token_pad = []
+        for prompt_token in next_prompt_token:
+            token = [self.pad_token_id] * (max_len - len(prompt_token)) + prompt_token
+            next_prompt_token_pad.append(token)
+
+        next_input_ids = torch.tensor(next_prompt_token_pad, dtype=torch.int64)
+        next_attention_mask = next_input_ids != self.pad_token_id
+        position_ids = torch.clip(torch.cumsum(next_attention_mask, dim=-1) - 1, min=0, max=None) * next_attention_mask
+        next_batch = TensorDict(
+            {
+                'input_ids': next_input_ids[:, -max_len:].cpu().share_memory_(),
+                'position_ids': position_ids[:, -max_len:].cpu().share_memory_(),
+                'attention_mask': next_attention_mask[:, -max_len:].to(dtype=torch.int64).cpu().share_memory_()
+            },
+            batch_size=next_input_ids.shape[0]
+        ).share_memory_()
+        
+        raw_prompt_ids = np.empty(len(next_raw_prompt_token), dtype=object)
+        raw_prompt_ids[:] = [x[-max_len:] for x in next_raw_prompt_token]
+
+        next_image_data = np.array([{"image": img} for img in next_image_data], dtype=object)
+        next_data = DataProto(batch=next_batch, non_tensor_batch={'raw_prompt_ids': raw_prompt_ids, 'multi_modal_data': next_image_data, })
+        next_data.meta_info.update(self.meta_info)
+        next_data.meta_info['index'] = next_sample_idx
+        next_data.meta_info['do_sample'] = False # step > 0 does not do sample
+        self.loop_cnt += 1
+        return next_data
+
+    def compose_final_output(self, step, group) -> DataProto:
+        print(f"[compose_final_output] start compose the final output, step is {step}", flush=True, file=sys.stderr)
+        """Compose final generation output."""
+        input_ids_list = []
+        loss_mask_list = []
+        length_list = []
+        
+        for idx, responses in enumerate(self.loop_responses_token):
+            loss_mask = []
+            prompts_list = list(itertools.chain.from_iterable(responses[1:]))
+            # responses_token: [prompt_token, reponse_token_1, info_token_1, response_token_2....]
+            for turn_idx in range(len(responses[1:])): 
+                length = len(responses[turn_idx + 1])
+                loss_mask.extend([(turn_idx + 1) % 2] * length)
+            input_ids_list.append(prompts_list)
+            loss_mask_list.append(loss_mask)
+            length_list.append(len(prompts_list))
+
+        max_response_length = torch.tensor([max(length_list)], device=torch.cuda.current_device())
+        # because only tp=0 will exec postprocess_output and compose_final_output
+        # so we exec all_reduce in specified group(dp group)
+        torch.distributed.all_reduce(max_response_length, op=torch.distributed.ReduceOp.MAX, group=group)
+        max_len = int(max_response_length)
+        
+        # right pad
+        input_ids = []
+        loss_mask = []
+        for idx, input_ids in enumerate(input_ids_list):
+            input_ids = input_ids + [self.pad_token_id] * (max_len - len(input_ids))
+            loss_mask = loss_mask_list[idx] + [0] * (max_len - len(loss_mask_list[idx]))
+            input_ids_list[idx] = input_ids
+            loss_mask_list[idx] = loss_mask[0:max_len]
+
+        response_token = torch.tensor(input_ids_list, dtype=torch.int64)[:,:max_len]
+        response_loss_mask = torch.tensor(loss_mask_list, dtype=torch.float32)
+        response_attention_mask = (response_token != self.pad_token_id).long()
+        # get the max length of the process rewards
+        max_tool_use_len = self.max_turns
+        for tool_use_item in self.tool_use:
+            max_tool_use_len = max(max_tool_use_len, len(tool_use_item))
+        tool_use_tensor = []
+
+        # Pad tool_use to have consistent dimensions
+        for idx in range(len(self.tool_use)):
+            if not self.tool_use[idx]:
+                padded_tool_use = [torch.nan] * max_tool_use_len
+            else:
+                padded_tool_use = self.tool_use[idx] + [torch.nan] * (max_tool_use_len - len(self.tool_use[idx]))
+            tool_use_tensor.append(padded_tool_use)
+
+        tool_use_score = torch.tensor(tool_use_tensor)
+        multi_modal_inputs = np.array(self.merge_multi_modal_inputs(self.multi_modal_inputs))
+        input_ids = torch.cat([self.init_prompt_token, response_token], dim=-1)
+        attention_mask = torch.cat([self.init_attention_mask, response_attention_mask], dim=-1)
+        if self.processor is not None and self.processor.image_processor._processor_class== "Qwen2_5_VLProcessor":
+            from verl.models.transformers.qwen2_vl import get_rope_index
+            position_ids = [] 
+            # breakpoint()
+            for idx, input_id in enumerate(input_ids):
+                try:
+                    position_id = get_rope_index(
+                            self.processor,
+                            input_ids=input_id,
+                            image_grid_thw=multi_modal_inputs[idx][0].get("image_grid_thw"),
+                            video_grid_thw=multi_modal_inputs[idx][0].get("video_grid_thw"),
+                            attention_mask=attention_mask[idx],
+                        )
+                    
+                    position_ids.append(position_id)
+                except:
+                    # 报错raise
+                    print(f"get_rope_index error, the input_ids is {input_id}")
+                    breakpoint()
+            
+            # Stack the 2D position_ids into a 3D tensor
+            position_ids = torch.stack(position_ids, dim=0)
+            
+        else:
+            position_ids = torch.clip(torch.cumsum(attention_mask, dim=-1) - 1, min=0, max=None) * attention_mask
+        loss_mask = torch.cat([torch.zeros_like(self.init_attention_mask, dtype=torch.float32), response_loss_mask], dim=-1)
+        final_batch = TensorDict(
+            {
+                'prompts': self.init_prompt_token,
+                'responses': response_token,
+                'input_ids': input_ids,
+                'attention_mask': attention_mask,
+                'position_ids': position_ids,
+                'loss_mask': loss_mask,
+                'tool_use_scores': tool_use_score
+            },
+            batch_size=self.batch_size,
+        )  
+        image_list = np.array([{"image": img} for img in self.image_list], dtype=object)
+        modal_inputs = np.array([inputs[0] for inputs in multi_modal_inputs])
+        
+        final_output = DataProto(
+            batch=final_batch,
+            non_tensor_batch={
+                'multi_modal_data': image_list, 
+                "multi_modal_inputs": modal_inputs
+            }
+        )
+        print("[Final Compose] finish final compose", flush=True, file=sys.stderr)
+        return final_output
+
+
+
+    
+    def merge_tensor_dicts(self, list_of_dicts):
+
+        if not list_of_dicts:
+            return {}
+
+        keys = list_of_dicts[0].keys()
+        merged_dict = {}
+
+        for key in keys:
+            tensors_to_concat = [d[key] for d in list_of_dicts]
+            merged_dict[key] = torch.cat(tensors_to_concat, dim=0)
+
+        return merged_dict
+
+    def merge_multi_modal_inputs(self,multi_modal_inputs):
+        """
+        Merges dictionaries within each sublist of multi_modal_inputs.
+        """
+        merged_inputs = []
+        for sublist in multi_modal_inputs:
+            merged_dict = self.merge_tensor_dicts(sublist)
+            merged_inputs.append([merged_dict])
+        return merged_inputs

--- a/envs/vision.py
+++ b/envs/vision.py
@@ -3,12 +3,17 @@ import json
 import string
 import torch
 import sys
-from .base import Env
 
-class VisionEnv(Env):
+from typing import List
+from PIL import Image
+from .mmbase import MMEnv
+
+class VisionEnv(MMEnv):
     def __init__(self, config, centralized_actor=None):
         super().__init__(config, centralized_actor)
         self.use_verify_tool = False
+        
+
 
     def get_step_reward(self, responses, format_score=0.1):
         step_reward = []

--- a/examples/data_preprocess/process_vl.py
+++ b/examples/data_preprocess/process_vl.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
                                 "You are a helpful assistant. "
                                 "\n# Tools\nEvery turn you can call one function at most among the following functions to assist with the user query."
                                 "\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n"
-                                '{"type": "function", "function": {"name": "rotate", "description": "Rotate a Pillow image by specified degrees", "parameters": {"type": "object", "properties": {"degree": {"type": "integer", "description": "Rotation angle in degrees"}}, "required": ["degree"]}}}\n</tools>\n'
+                                '{"type": "function", "function": {"name": "vision-rotate", "description": "Rotate a Pillow image by specified degrees", "parameters": {"type": "object", "properties": {"degree": {"type": "integer", "description": "Rotation angle in degrees"}}, "required": ["degree"]}}}\n</tools>\n'
                                 'For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n'
                                 '<tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call>\nThe tool response will wrapped with <tool_response></tool_response> XML tags. '
                                 

--- a/main_ppo.sh
+++ b/main_ppo.sh
@@ -1,7 +1,4 @@
 set -e -x
-FILE="$(pwd)/verl/utils/reward_score/search.py"
-FUNCTION_NAME="compute_score"
-
 
 export MODEL_PATH='your/path/to/Qwen/Qwen3-4B'
 export REWARD_MODEL_PATH=/your/path/to/huggingface.co/Qwen/QwQ-32B
@@ -9,7 +6,9 @@ export TRAIN_DATA='your/path/to/data/hotpot/train.parquet'
 export TEST_DATA='your/path/to/data/hotpot/test.parquet'
 # export VLLM_ATTENTION_BACKEND=XFORMERS
 
-python3 -m verl.trainer.main_ppo\
+
+
+python3 -m verl.trainer.main_ppo --config-name=rl_factory_ppo_trainer \
     algorithm.adv_estimator=gae\
     data.train_files=$TRAIN_DATA\
     data.val_files=$TEST_DATA\
@@ -51,8 +50,6 @@ python3 -m verl.trainer.main_ppo\
     reward_rollout.rollout.model_name=$REWARD_MODEL_PATH\
     reward_rollout.rollout.free_cache_engine=False\
     reward_model.reward_manager=parallel\
-    custom_reward_function.path=$FILE\
-    custom_reward_function.name=$FUNCTION_NAME\
     algorithm.kl_ctrl.kl_coef=0.001\
     trainer.critic_warmup=0\
     trainer.logger=['tensorboard']\

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -21,8 +21,9 @@ import copy
 import logging
 import os
 import pickle
+from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Callable, Optional
+from typing import Callable, Optional, Union, Any
 
 import numpy as np
 import pandas as pd
@@ -771,7 +772,7 @@ class DataProto:
 
     def repeat(self, repeat_times=2, interleave=True):
         """
-        Repeat the batch data a specified number of times.
+        Repeat the batch data a specified number of times with deep copy guarantee.
 
         Args:
             repeat_times (int): Number of times to repeat the data.
@@ -780,37 +781,40 @@ class DataProto:
         Returns:
             DataProto: A new DataProto with repeated data.
         """
+        # Handle tensor batch
         if self.batch is not None:
-            if interleave:
-                # Interleave the data
-                repeated_tensors = {
-                    key: tensor.repeat_interleave(repeat_times, dim=0) for key, tensor in self.batch.items()
-                }
-            else:
-                # Stack the data
-                repeated_tensors = {
-                    key: tensor.unsqueeze(0).expand(repeat_times, *tensor.shape).reshape(-1, *tensor.shape[1:])
-                    for key, tensor in self.batch.items()
-                }
+            repeated_tensors = {}
+            for key, tensor in self.batch.items():
+                if interleave:
+                    # 使用深拷贝的交错重复
+                    repeated_tensors[key] = tensor.clone().repeat_interleave(repeat_times, dim=0)
+                else:
+                    # 使用深拷贝的非交错重复
+                    repeated_tensors[key] = torch.cat([tensor.clone()] * repeat_times, dim=0)
 
             repeated_batch = TensorDict(
                 source=repeated_tensors,
                 batch_size=(self.batch.batch_size[0] * repeat_times,),
+                device=self.batch.device,
             )
         else:
             repeated_batch = None
 
+        # Handle non-tensor batch with deep copy
         repeated_non_tensor_batch = {}
         for key, val in self.non_tensor_batch.items():
             if interleave:
-                repeated_non_tensor_batch[key] = np.repeat(val, repeat_times, axis=0)
+                repeated_non_tensor_batch[key] = _repeat_interleave(val, repeat_times)
             else:
-                repeated_non_tensor_batch[key] = np.tile(val, (repeat_times,) + (1,) * (val.ndim - 1))
+                repeated_non_tensor_batch[key] = _repeat_tile(val, repeat_times)
+
+        # Deep copy meta_info to ensure complete isolation
+        repeated_meta_info = deepcopy(self.meta_info)
 
         return type(self)(
             batch=repeated_batch,
             non_tensor_batch=repeated_non_tensor_batch,
-            meta_info=self.meta_info,
+            meta_info=repeated_meta_info,
         )
 
     def unfold_column_chunks(self, n_split: int, split_keys: Optional[list[str]] = None):
@@ -993,3 +997,82 @@ def broadcast_data_proto(data: DataProto, process_group, group_src: int):
     meta_info_list = [data.meta_info]
     torch.distributed.broadcast_object_list(meta_info_list, group=process_group, group_src=group_src)
     data.meta_info = meta_info_list[0]
+
+def _deep_copy_value(val):
+    """深拷贝各种类型的值，特别处理PIL.Image等特殊对象"""
+    try:
+        # 检查是否是PIL.Image或其他有copy方法的对象
+        if hasattr(val, 'copy') and hasattr(val, 'mode'):  # PIL.Image特征
+            return val.copy()
+        elif isinstance(val, list):
+            # 处理列表，递归深拷贝每个元素
+            return [_deep_copy_value(item) for item in val]
+        elif isinstance(val, dict):
+            # 处理字典，递归深拷贝每个值
+            return {key: _deep_copy_value(value) for key, value in val.items()}
+        elif isinstance(val, tuple):
+            # 处理元组
+            return tuple(_deep_copy_value(item) for item in val)
+        else:
+            # 其他类型使用标准深拷贝
+            return deepcopy(val)
+    except Exception:
+        # 如果深拷贝失败，尝试使用copy方法或返回原对象
+        if hasattr(val, 'copy'):
+            return val.copy()
+        else:
+            return val
+
+
+def _repeat_interleave(value: Union[torch.Tensor, np.ndarray], repeats: int) -> Union[torch.Tensor, list[Any]]:
+    if isinstance(value, torch.Tensor):
+        # 使用 clone() 确保深拷贝，避免内存共享
+        return value.clone().repeat_interleave(repeats, dim=0)
+    elif isinstance(value, np.ndarray):
+        # 检查是否是包含复杂对象的numpy数组
+        if value.dtype == object:
+            # 对于包含复杂对象（如PIL.Image、字典等）的numpy数组，需要特殊处理
+            # 形式: [A,B] -> [A,A,B,B] (每个元素重复repeats次)
+            repeated_list = []
+            for item in value:
+                for _ in range(repeats):
+                    # 使用辅助函数深拷贝复杂对象
+                    repeated_list.append(_deep_copy_value(item))
+            return np.array(repeated_list, dtype=object)
+        else:
+            # 对于普通numpy数组，使用copy()后重复
+            return np.repeat(value.copy(), repeats, axis=0)
+    else:
+        # 对其他类型（如列表等）使用深拷贝后重复
+        # 形式: [A,B] -> [A,A,B,B] (每个元素重复repeats次)
+        repeated_list = []
+        for item in value:
+            for _ in range(repeats):
+                repeated_list.append(deepcopy(item))
+        return repeated_list
+
+
+def _repeat_tile(value: Union[torch.Tensor, np.ndarray], repeats: int) -> Union[torch.Tensor, list[Any]]:
+    """非交错重复，形式: [A,B] -> [A,B,A,B]"""
+    if isinstance(value, torch.Tensor):
+        # 使用torch.cat确保深拷贝
+        return torch.cat([value.clone()] * repeats, dim=0)
+    elif isinstance(value, np.ndarray):
+        if value.dtype == object:
+            # 对于包含复杂对象的numpy数组
+            # 形式: [A,B] -> [A,B,A,B] (整个数组重复repeats次)
+            repeated_list = []
+            for _ in range(repeats):
+                for item in value:
+                    repeated_list.append(_deep_copy_value(item))
+            return np.array(repeated_list, dtype=object)
+        else:
+            # 对于普通numpy数组
+            return np.tile(value.copy(), (repeats,) + (1,) * (value.ndim - 1))
+    else:
+        # 对其他类型
+        repeated_list = []
+        for _ in range(repeats):
+            for item in value:
+                repeated_list.append(deepcopy(item))
+        return repeated_list

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -770,6 +770,54 @@ class DataProto:
         self.batch = self.batch[indices]
         self.non_tensor_batch = {key: val[indices_np] for key, val in self.non_tensor_batch.items()}
 
+
+
+
+    # def repeat(self, repeat_times=2, interleave=True):
+    #     """
+    #     Repeat the batch data a specified number of times.
+
+    #     Args:
+    #         repeat_times (int): Number of times to repeat the data.
+    #         interleave (bool): Whether to interleave the repeated data.
+
+    #     Returns:
+    #         DataProto: A new DataProto with repeated data.
+    #     """
+    #     if self.batch is not None:
+    #         if interleave:
+    #             # Interleave the data
+    #             repeated_tensors = {
+    #                 key: tensor.repeat_interleave(repeat_times, dim=0) for key, tensor in self.batch.items()
+    #             }
+    #         else:
+    #             # Stack the data
+    #             repeated_tensors = {
+    #                 key: tensor.unsqueeze(0).expand(repeat_times, *tensor.shape).reshape(-1, *tensor.shape[1:])
+    #                 for key, tensor in self.batch.items()
+    #             }
+
+    #         repeated_batch = TensorDict(
+    #             source=repeated_tensors,
+    #             batch_size=(self.batch.batch_size[0] * repeat_times,),
+    #         )
+    #     else:
+    #         repeated_batch = None
+
+    #     repeated_non_tensor_batch = {}
+    #     for key, val in self.non_tensor_batch.items():
+    #         if interleave:
+    #             repeated_non_tensor_batch[key] = np.repeat(val, repeat_times, axis=0)
+    #         else:
+    #             repeated_non_tensor_batch[key] = np.tile(val, (repeat_times,) + (1,) * (val.ndim - 1))
+
+    #     return type(self)(
+    #         batch=repeated_batch,
+    #         non_tensor_batch=repeated_non_tensor_batch,
+    #         meta_info=self.meta_info,
+    #     )
+
+
     def repeat(self, repeat_times=2, interleave=True):
         """
         Repeat the batch data a specified number of times with deep copy guarantee.

--- a/verl/trainer/config/rl_factory_ppo_trainer.yaml
+++ b/verl/trainer/config/rl_factory_ppo_trainer.yaml
@@ -39,6 +39,9 @@ actor_rollout_ref:
     max_size: 1000
     persist_dir: ./cache
     local_cache: null
+    mmtool: False
+    load_custom_chat_template: null
+
 
 
 trainer:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -724,6 +724,7 @@ class RayPPOTrainer:
             non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
             if "multi_modal_data" in test_batch.non_tensor_batch:
                 non_tensor_batch_keys_to_pop.append("multi_modal_data")
+                non_tensor_batch_keys_to_pop.append("multi_modal_inputs")
             if "raw_prompt" in test_batch.non_tensor_batch:
                 non_tensor_batch_keys_to_pop.append("raw_prompt")
             if "tools_kwargs" in test_batch.non_tensor_batch:

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -26,7 +26,9 @@ def process_image(image: dict | Image.Image) -> Image.Image:
 
     if "bytes" in image:
         assert "image" not in image, "Cannot have both `bytes` and `image`"
-        image["image"] = BytesIO(image["bytes"])
+        # image["image"] = BytesIO(image["bytes"])
+        image["image"] = Image.open(BytesIO(image["bytes"])).convert("RGB")
+
 
     return fetch_image(image)
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -75,6 +75,7 @@ from verl.utils.py_functional import convert_to_regular_types
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 from verl.protocol import broadcast_data_proto
 from envs.utils.tool_utils import ToolUtils
+from envs.utils.mm_tool_utils import MMToolUtils
 from envs import TOOL_ENV_REGISTRY
 
 logger = logging.getLogger(__file__)
@@ -829,8 +830,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         prompts.meta_info.update(meta_info)
 
-        su = ToolUtils(self.tokenizer, meta_info, self.rollout.config, env_object=self.env_object)
-
+        if self.config.env.mmtool:
+            su = MMToolUtils(self.tokenizer, processor=self.processor, meta_info=meta_info, config=self.rollout.config, env_object=self.env_object)
+        else:
+            su = ToolUtils(self.tokenizer, meta_info, self.rollout.config, env_object=self.env_object)
         with self.rollout_sharding_manager:
 
             # after parameters sync with rollout, offload actor model to CPU

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -27,7 +27,9 @@ When working with Megatron:
 """
 
 import logging
-import os
+import os,sys
+from typing import Any, Dict, List, Union
+
 import pickle
 import socket
 import threading
@@ -273,12 +275,12 @@ class vLLMRollout(BaseRollout):
         if "multi_modal_data" in non_tensor_batch:
             vllm_inputs = []
             for raw_prompt_ids, multi_modal_data in zip(
-                non_tensor_batch.pop("raw_prompt_ids"), non_tensor_batch.pop("multi_modal_data"), strict=True
+                non_tensor_batch.get("raw_prompt_ids"), non_tensor_batch.get("multi_modal_data"), strict=True
             ):
                 vllm_inputs.append({"prompt_token_ids": raw_prompt_ids, "multi_modal_data": multi_modal_data})
         else:
             vllm_inputs = [
-                {"prompt_token_ids": raw_prompt_ids} for raw_prompt_ids in non_tensor_batch.pop("raw_prompt_ids")
+                {"prompt_token_ids": raw_prompt_ids} for raw_prompt_ids in non_tensor_batch.get("raw_prompt_ids")
             ]
 
         # ensure the type of `prompt_token_ids` passed to vllm is list[int]


### PR DESCRIPTION
合并 分支verl_0_5与vllm_tool分支
相比verl_0_5分支修改如下：
1：verl部分：
verl/protocol.py：修改repeat 采用vllm-tool中的深拷贝，避免多模态出现问题
verl/trainer/config/rl_factory_ppo_trainer.yaml：增加vllm-tool中多模态的新增参数
verl/trainer/ppo/ray_trainer.py：为_validate函数增加 multi_modal_inputs 的 popkey
verl/utils/dataset/vision_utils.py：修改了process_image 函数处理bytes数据代码，改为返回图像
verl/workers/fsdp_workers.py：增加tool_utils的多模态参数判定
verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py：将pop改为get，多模态需要其中的数据，因此需要保留数据
2：envs部分：
直接复用（增加）vllm-tool中的多模态相关代码：envs/configs/chat_template.jinja ；envs/mmbase.py ；envs/tool_manager/mm_base_manager.py； envs/tool_manager/qwen2_5_vl_manager.py； envs/tools/rotate.py envs/utils/mm_tool_utils.py； envs/vision.py
envs/__init__.py 增加 MMEnv 
envs/configs/mcp_vision_tools.pydata ：修改其中的mcpsercers为”vision“ 从而 工具名称为”vision“+”-“+”函数名“
examples/data_preprocess/process_vl.py：同步修改了多模态数据的工具名称
examples/rl_factory/qwen25vl_tool.sh：修改的verl0.5对应的运行脚本
envs/utils/mcp_manager.py：根据讨论结果去除其中Toolclass 中call的异步方式，修改为原始版本
main_ppo.sh:：修改的verl0.5对应的ppo运行脚本
