### PR TITLE
添加max_num_seqs参数的设置

### DIFF
--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -1322,6 +1322,12 @@ class RewardRolloutWorker(MegatronWorker, DistProfilerExtension):
                 # expert_tensor_parallel_size=self.config.actor.megatron.expert_tensor_parallel_size,
             )
 
+        DistProfilerExtension.__init__(
+            self, DistProfiler(rank=self.rank, 
+                               config=omega_conf_to_dataclass(config.get("profiler")), 
+                               option=kwargs.get("profile_option", None))
+        )
+
         set_random_seed(seed=self.config.rollout.seed)
 
         self.role = role


### PR DESCRIPTION
- 在AysncvLLMServer类中添加了max_num_seqs参数的设置逻辑
- 目前max_num_seqs可以在shell脚本中进行配置，配置方法为
同步工具调用：+actor_rollout_ref.rollout.engine_kwargs.vllm.max_num_seqs=1
异步工具调用：actor_rollout_ref.rollout.max_num_seqs=1024