### PR TITLE
[mcp] feature: Add MCP timeout handling and reconnection

### DIFF
--- a/envs/utils/async_mcp_manager.py
+++ b/envs/utils/async_mcp_manager.py
@@ -114,3 +114,7 @@ class AsyncMCPManager(SSEMCPManager):
             config=self._config,
             manager_classes=self.manager_classes
         )
+
+    async def _init_client_with_retry(self, client, server_name, server, max_retries=10):
+        """重写_init_client_with_retry方法，调用父类的方法"""
+        return await super()._init_client_with_retry(client, server_name, server, max_retries)


### PR DESCRIPTION
Add MCP timeout handling and retry mechanisms

- Add BaseExceptionGroup import for Python compatibility
- Implement retry mechanism with exponential backoff for client initialization
- Add timeout handling for connections (30s) and cleanup (5s)
- Improve error handling for timeout and connection errors
- Add reconnect logic for failed operations